### PR TITLE
Alter `sys.path` to allow use directly shinx-build

### DIFF
--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -16,9 +16,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../..'))
 
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
Always it should be possible to build documentation without actual
module installation or using tox/venv. That patch guarantees that
Documentation would be built from the source tree and not against
the installed module.

Signed-off-by: Tomasz Kłoczko <kloczek@github.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phynix/yamlloader/31)
<!-- Reviewable:end -->
