### PR TITLE
deps: add PyYaml module as runtime requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ classifiers = [
 
 dynamic = [ "version" ]
 
+dependencies = [ "pyyaml" ]
+
 optional-dependencies.dev = [ "yamlloader[test,doc]" ]
 optional-dependencies.doc = [ "sphinx", "sphinx-autodoc-typehints", "sphinx-rtd-theme", "sphinxcontrib-apidoc" ]
 optional-dependencies.test = [ "coverage", "hypothesis" ]


### PR DESCRIPTION
PyYaml is used everywhere in yamlloader, but is not included as a dependency of yamlloader itself. The absence of this module in the environment results in the following import error:
```
>>> import yamlloader
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/tmp/venv/lib64/python3/site-packages/yamlloader/__init__.py", line 5, in <module>
    from . import ordereddict
  File "/tmp/venv/lib64/python3/site-packages/yamlloader/ordereddict/__init__.py", line 3, in <module>
    from .dumpers import Dumper, SafeDumper, CDumper, CSafeDumper
  File "/tmp/venv/lib64/python3/site-packages/yamlloader/ordereddict/dumpers.py", line 7, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```